### PR TITLE
clean up basic lints

### DIFF
--- a/encrypt.go
+++ b/encrypt.go
@@ -5,9 +5,9 @@ import (
 	"encoding/binary"
 )
 
-func createHash(version, seq uint8, sessionId uint32, key, lastHash []byte) []byte {
+func createHash(version, seq uint8, sessionID uint32, key, lastHash []byte) []byte {
 	h := md5.New()
-	binary.Write(h, binary.BigEndian, sessionId)
+	binary.Write(h, binary.BigEndian, sessionID)
 	h.Write(key)
 	binary.Write(h, binary.BigEndian, version)
 	binary.Write(h, binary.BigEndian, seq)
@@ -15,10 +15,10 @@ func createHash(version, seq uint8, sessionId uint32, key, lastHash []byte) []by
 	return h.Sum(nil)
 }
 
-func crypt(data, key []byte, version, seq uint8, sessionId uint32) {
+func crypt(data, key []byte, version, seq uint8, sessionID uint32) {
 	var lastHash []byte
 	for i := 0; i < len(data); i += 16 {
-		hash := createHash(version, seq, sessionId, key, lastHash)
+		hash := createHash(version, seq, sessionID, key, lastHash)
 		lastHash = hash[:]
 		for j := 0; j < len(hash); j++ {
 			if i+j < len(data) {

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -9,7 +9,7 @@ import (
 type packetData struct {
 	version   packetVer
 	seq       uint8
-	sessionId uint32
+	sessionID uint32
 	key       []byte
 }
 
@@ -25,7 +25,7 @@ var hashTests = []hashTest{
 		packetData{
 			version:   TAC_PLUS_VER_DEFAULT,
 			seq:       1,
-			sessionId: 1581998937,
+			sessionID: 1581998937,
 			key:       []byte("test"),
 		},
 	},
@@ -33,7 +33,7 @@ var hashTests = []hashTest{
 		packetData{
 			version:   TAC_PLUS_VER_DEFAULT,
 			seq:       1,
-			sessionId: 1581998937,
+			sessionID: 1581998937,
 			key:       []byte("test"),
 		},
 	},
@@ -43,7 +43,7 @@ func TestHash(t *testing.T) {
 	for i, test := range hashTests {
 		lastHash := make([]byte, hex.DecodedLen(len(test.lastHash)))
 		hex.Decode(lastHash, test.lastHash)
-		calcHash := createHash(uint8(test.version), test.seq, test.sessionId, test.key, lastHash)
+		calcHash := createHash(uint8(test.version), test.seq, test.sessionID, test.key, lastHash)
 		expectedHash, _ := hex.DecodeString(test.expected)
 		if !bytes.Equal(calcHash, expectedHash) {
 			t.Errorf("%d %s: expected '%x', got '%x'", i, test.name, expectedHash, calcHash)
@@ -64,7 +64,7 @@ var cryptTests = []cryptTest{
 		packetData{
 			version:   TAC_PLUS_VER_DEFAULT,
 			seq:       1,
-			sessionId: 1581998937,
+			sessionID: 1581998937,
 			key:       []byte("test"),
 		},
 	},
@@ -73,7 +73,7 @@ var cryptTests = []cryptTest{
 func TestCrypt(t *testing.T) {
 	for _, test := range cryptTests {
 		calc := test.uncryptedData[:]
-		crypt(calc, test.key, uint8(test.version), test.seq, test.sessionId)
+		crypt(calc, test.key, uint8(test.version), test.seq, test.sessionID)
 		expected := make([]byte, hex.DecodedLen(len(test.cryptedData)))
 		hex.Decode(expected, test.cryptedData)
 		if !bytes.Equal(calc, expected) {

--- a/packet.go
+++ b/packet.go
@@ -165,7 +165,7 @@ type packet struct {
 	packetType uint8
 	seq        uint8
 	flags      uint8
-	sessionId  uint32
+	sessionID  uint32
 	data       []byte
 }
 
@@ -188,7 +188,7 @@ func (p *packet) serialize(w io.Writer) error {
 	b.uint8(p.packetType)
 	b.uint8(p.seq)
 	b.uint8(p.flags)
-	b.uint32(p.sessionId)
+	b.uint32(p.sessionID)
 	b.uint32(uint32(len(p.data)))
 
 	ew := errWriter{w: w}
@@ -216,7 +216,7 @@ func (p *packet) parse(r io.Reader) error {
 	p.packetType = b.uint8()
 	p.seq = b.uint8()
 	p.flags = b.uint8()
-	p.sessionId = b.uint32()
+	p.sessionID = b.uint32()
 	dataLen := b.uint32()
 
 	er := errReader{r: r}
@@ -233,7 +233,7 @@ func (p *packet) cryptData(key []byte) {
 		return
 	}
 
-	crypt(p.data, key, uint8(p.version), p.seq, p.sessionId)
+	crypt(p.data, key, uint8(p.version), p.seq, p.sessionID)
 	return
 }
 
@@ -280,7 +280,7 @@ func (s *authenStart) parse(data []byte) error {
 	dataLen := b.uint8()
 
 	if len(data) != int(authenStartHeaderLen+userLen+portLen+remAddrLen+dataLen) {
-		return fmt.Errorf("Invalid AUTHEN START packet. Possibly key mismatch.")
+		return fmt.Errorf("Invalid AUTHEN START packet. Possibly key mismatch")
 	}
 
 	er := errReader{r: r}
@@ -358,7 +358,7 @@ func (p *authenReply) parse(data []byte) error {
 	dataLen := b.uint16()
 
 	if len(data) != int(authenReplyHeaderLen+serverMsgLen+dataLen) {
-		return fmt.Errorf("Invalid AUTHEN REPLY packet. Possibly key mismatch.")
+		return fmt.Errorf("Invalid AUTHEN REPLY packet. Possibly key mismatch")
 	}
 
 	er := errReader{r: r}
@@ -420,7 +420,7 @@ func (p *authenContinue) parse(data []byte) error {
 	p.flags = b.uint8()
 
 	if len(data) != int(authenContinueHeaderLen+userMsgLen+dataLen) {
-		return fmt.Errorf("Invalid AUTHEN CONTINUE packet. Possibly key mismatch.")
+		return fmt.Errorf("Invalid AUTHEN CONTINUE packet. Possibly key mismatch")
 	}
 
 	er := errReader{r: r}

--- a/server.go
+++ b/server.go
@@ -10,10 +10,11 @@ import (
 type session struct {
 	conn      net.Conn
 	seq       uint8
-	sessionId uint32
+	sessionID uint32
 	key       []byte
 }
 
+// NewSession creates a new tacacs state session
 func NewSession(conn net.Conn) *session {
 	return &session{
 		conn: conn,
@@ -24,7 +25,7 @@ func (s *session) Handle() {
 	peer, _, _ := net.SplitHostPort(s.conn.RemoteAddr().String())
 	names, err := net.LookupAddr(peer)
 	if err != nil {
-		fmt.Println("Could not loopup name for address: %s", peer)
+		fmt.Printf("Could not loopup name for address: %s\n", peer)
 	}
 
 	fmt.Printf("New connection from %s (%s)\n", names[0], peer)
@@ -87,11 +88,11 @@ func (s *session) readPacket() *packet {
 	// Go ahead and increment the sequence when we receive a packet
 	s.seq = p.seq + 1
 
-	if s.sessionId == 0 {
+	if s.sessionID == 0 {
 		// New session, set the session ID
-		s.sessionId = p.sessionId
-	} else if s.sessionId != p.sessionId {
-		fmt.Printf("Invalid session id.  Got '%x', expected '%x,", p.sessionId, s.sessionId)
+		s.sessionID = p.sessionID
+	} else if s.sessionID != p.sessionID {
+		fmt.Printf("Invalid session id.  Got '%x', expected '%x,", p.sessionID, s.sessionID)
 		return nil
 	}
 
@@ -106,7 +107,7 @@ func (s *session) genPacket(packetType uint8, ver packetVer) *packet {
 		packetType: packetType,
 		version:    ver,
 		seq:        s.seq,
-		sessionId:  s.sessionId,
+		sessionID:  s.sessionID,
 	}
 	return p
 }


### PR DESCRIPTION
clean up Id vs ID lint & error ends in punctuation lint (didn't touch ALL_CAPS_THINGS or unexported struct lints at this point)

Test output:
```
 jda@rin  ~/go/src/github.com/jda/tictac   master  go test -v
=== RUN   TestHash
--- PASS: TestHash (0.00s)
=== RUN   TestCrypt
--- PASS: TestCrypt (0.00s)
PASS
ok  	github.com/jda/tictac	0.002s
```